### PR TITLE
Refactor get_targets and llvm modules

### DIFF
--- a/src/commands/get_targets.rs
+++ b/src/commands/get_targets.rs
@@ -108,7 +108,7 @@ mod tests {
             path: test_dir.to_string_lossy().into_owned(),
             output: output_file.to_string_lossy().into_owned(),
         };
-        run(args, &logger);
+        let _ = run(args, &logger);
 
         let output = fs::read_to_string(&output_file).unwrap();
         let expected = fs::read_to_string(&expected_file).unwrap();

--- a/src/commands/llvm.rs
+++ b/src/commands/llvm.rs
@@ -8,7 +8,6 @@ use xshell::Shell;
 const LLVM_INSTRUMENTOR_PATH: &str = "./llvm/afl-clang-fast";
 
 const AFL_CC: &str = "clang-11";
-const AFL_QUIET: &str = "1";
 
 #[derive(Parser, Debug)]
 pub struct LlvmArgs {


### PR DESCRIPTION
- Update get_targets.rs to suppress the result of the run function for cleaner test output.
- Remove unused AFL_QUIET constant from llvm.rs to streamline the codebase.